### PR TITLE
Fixing the elastic beanstalk config to work for the static images

### DIFF
--- a/.ebextensions/options.config
+++ b/.ebextensions/options.config
@@ -1,7 +1,5 @@
 option_settings:
   aws:elasticbeanstalk:application:environment:
     AWS_REGION: '`{"Ref" : "AWS::Region"}`'
-  aws:elasticbeanstalk:container:nodejs:
-    ProxyServer: nginx
-  aws:elasticbeanstalk:container:nodejs:staticfiles:
-    /static: /static
+  aws:elasticbeanstalk:environment:proxy:staticfiles:
+    "/static": "/static"


### PR DESCRIPTION
I kept getting the following error when trying to create my EB environment.

`Invalid option specification (Namespace: 'aws:elasticbeanstalk:container:nodejs:staticfiles', OptionName: '/static'): Unknown configuration setting.`

After making this change and repacking the zip the environment stood up correctly.

I removed  the second option because if you read the docs that is the default option for a ProxyServer is nginx
https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-specific.html#command-options-nodejs